### PR TITLE
Naming in CMakeLists.txt

### DIFF
--- a/ETHZ_experiments/catkin_ws/src/sensors/CMakeLists.txt
+++ b/ETHZ_experiments/catkin_ws/src/sensors/CMakeLists.txt
@@ -56,7 +56,7 @@ catkin_python_setup()
 ## Generate messages in the 'msg' folder
 add_message_files(
   FILES
-  USS.msg
+  uss.msg
   TOF.msg
 )
 


### PR DESCRIPTION
The name of the USS message file was incorrect in the CMakeLists.txt file, quick fix 